### PR TITLE
Skeleton loading page for articles page

### DIFF
--- a/src/app/article/[id]/page.tsx
+++ b/src/app/article/[id]/page.tsx
@@ -2,6 +2,8 @@ import AddArticleForm from "@/app/admin/AddArticleForm"
 import AddCommentForm from "@/app/components/Comment/AddCommentForm"
 import CommentItem from "@/app/components/Comment/CommentItem"
 import {typeArticles} from "@/utils/types"
+import { promises } from "dns"
+import { resolve } from "path"
 
 interface singleArticle{
     params: {id: string}

--- a/src/app/article/loading.tsx
+++ b/src/app/article/loading.tsx
@@ -1,0 +1,23 @@
+const ArticlesSkeleton = [1, 2, 3, 4, 5, 6];
+
+const LoadingArticle = () => {
+    return (
+        <section className="fix-height px-5 m-auto animate-pulse">
+            <div className='my-5 w-full md:w-2/3 m-auto bg-gray-300 h-12'></div>
+            <div className="flex justify-center items-center flex-wrap gap-7" >
+                {ArticlesSkeleton.map((item) => (
+                    <div key={item} className="p-5 rounded-lg my-1 bg-gray-200 w-full md:w-2/5 lg:w-1/4">
+                        <h1 className=" bg-gray-300 h-6 "></h1>
+                        <p className="my-2 bg-gray-300 p-1 h-10 "></p>
+                        <div className="bg-gray-300 h-6 w-full block text-center p-1 rounded-lg"></div>
+                    </div>
+                ))}
+            </div>
+            <div className="flex justify-center items-center space-x-2 m-auto my-5">
+                <div className="bg-gray-300 h-6 w-48 rounded-sm"></div>
+            </div>
+        </section>
+    );
+};
+
+export default LoadingArticle;

--- a/src/app/article/page.tsx
+++ b/src/app/article/page.tsx
@@ -3,9 +3,11 @@ import Article from "../components/Article/Article";
 import { typeArticles } from "@/utils/types"
 import SearchArticle from "../components/Article/SearchArticle";
 import Pagination from "../components/Article/pagination";
+import { resolve } from "dns/promises";
 
 
 const Articlepage = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 3000));
     const getArticles = await fetch("https://jsonplaceholder.typicode.com/posts");
 
     if (!getArticles.ok) {


### PR DESCRIPTION
Add loading skeleton for article placeholders with responsive layout

- Implemented a `LoadingArticle` component to render skeleton loaders for six articles.
- Added flexbox layout with `justify-center`, `items-center`, and `flex-wrap` for responsive alignment.
- Used `animate-pulse` to create a smooth loading effect.
- Applied background placeholders with `bg-gray-300` and appropriate heights for title, description, and button areas.
- Included a responsive grid layout using `w-full`, `md:w-2/5`, and `lg:w-1/4` for various screen sizes.
- Added a placeholder for pagination/loading button at the bottom of the section