### PR TITLE
Integrate with db to get a single article

### DIFF
--- a/src/app/api/articles/[id]/route.tsx
+++ b/src/app/api/articles/[id]/route.tsx
@@ -1,6 +1,7 @@
-import { NextRequest,NextResponse } from "next/server";
-import {articlesData} from "@/utils/data"
-import {updateArticle} from "@/utils/postType"
+import { NextRequest, NextResponse } from "next/server";
+import { articlesData } from "@/utils/data"
+import { updateArticle } from "@/utils/postType"
+import prisma from "@/utils/db";
 
 
 
@@ -15,16 +16,21 @@ import {updateArticle} from "@/utils/postType"
     - Imported articles data from the utils/data file for the response.
  */
 
-interface articleId{
-    params: {id:string}
+interface articleId {
+    params: { id: string }
 }
 
-export function GET(request:NextRequest, {params}:articleId){
-    const singleArticle = articlesData.find(a => a.id === parseInt(params.id));
-    if(!singleArticle){
-        return NextResponse.json({message:"Article Not Found"},{status:404})
+export async function GET(request: NextRequest, { params }: articleId) {
+    try {
+        const singleArticle = prisma.article.findUnique({where:{id:parseInt(params.id)}})
+        if(!singleArticle){
+            return NextResponse.json({message:"Article Not Found"},{status:404})
+        }
+        return NextResponse.json({singleArticle},{status:200});
+    } catch (error) {
+        console.error("Error fetching article:", error); // Log the actual error
+        return NextResponse.json({ message: "Internal server error" }, { status: 500 });
     }
-    return NextResponse.json({singleArticle},{status:200});
 }
 
 
@@ -39,42 +45,40 @@ export function GET(request:NextRequest, {params}:articleId){
     - Imported articles data from the utils/data file for the response.
  */
 
-    interface articleId{
-        params: {id:string}
+interface articleId {
+    params: { id: string }
+}
+
+export async function PUT(request: NextRequest, { params }: articleId) {
+    const singleArticle = articlesData.find(a => a.id === parseInt(params.id));
+    if (!singleArticle) {
+        return NextResponse.json({ message: "Article Not Found" }, { status: 404 })
     }
-    
-    export async function PUT(request:NextRequest, {params}:articleId){
-        const singleArticle = articlesData.find(a => a.id === parseInt(params.id));
-        if(!singleArticle){
-            return NextResponse.json({message:"Article Not Found"},{status:404})
-        }
-        const body = (await request.json()) as updateArticle ;
-        console.log(body)
-        return NextResponse.json({message:"Article updated"},{status:200});
-    }
+    const body = (await request.json()) as updateArticle;
+    console.log(body)
+    return NextResponse.json({ message: "Article updated" }, { status: 200 });
+}
 
 
-    /**
- * @method DELETE 
- * @route http://localhost:3000/api/articles/:id
- * @access public
- * @description 
- *  - Created PUT handler for update single article data using Next.js API routes.
-    - Utilized `NextRequest` and `NextResponse` from "next/server" to return the data.
-    - Added a status code of 200 for successful responses.
-    - Imported articles data from the utils/data file for the response.
- */
+/**
+* @method DELETE 
+* @route http://localhost:3000/api/articles/:id
+* @access public
+* @description 
+*  - Created delete handler for delete single article data using Next.js API routes.
+- Utilized `NextRequest` and `NextResponse` from "next/server" to return the data.
+- Added a status code of 200 for successful responses.
+- Imported articles data from the utils/data file for the response.
+*/
 
-    interface articleId{
-        params: {id:string}
+interface articleId {
+    params: { id: string }
+}
+
+export async function DELETE(request: NextRequest, { params }: articleId) {
+    const singleArticle = articlesData.find(a => a.id === parseInt(params.id));
+    if (!singleArticle) {
+        return NextResponse.json({ message: "Article Not Found" }, { status: 404 })
     }
-    
-    export async function DELETE(request:NextRequest, {params}:articleId){
-        const singleArticle = articlesData.find(a => a.id === parseInt(params.id));
-        if(!singleArticle){
-            return NextResponse.json({message:"Article Not Found"},{status:404})
-        }
-        const body = (await request.json()) as updateArticle ;
-        console.log(body)
-        return NextResponse.json({message:"Article updated"},{status:200});
-    }
+    return NextResponse.json({ message: "Article deleted" }, { status: 200 });
+}


### PR DESCRIPTION
Add Prisma Client integration to fetch a single article by ID

- Implemented GET handler using Prisma Client to retrieve a single article by its `id`.
- Utilized `prisma.article.findUnique()` to query the database for a specific article.
- Added error handling for cases where the article is not found, returning a 404 status with an appropriate message.
- Properly handled internal server errors with logging and 500 status code.
- Improved code structure for handling `params.id` and parsing it as an integer for database queries.
- Response includes the article data or a descriptive error message based on the outcome.