### PR TITLE
Add verifyToken utility function for JWT verification in utils

### DIFF
--- a/src/app/api/user/profile/[id]/route.ts
+++ b/src/app/api/user/profile/[id]/route.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client"
 import prisma from "@/utils/db";
 import jsonwebtoken from 'jsonwebtoken';
 import { typeJwt } from "@/utils/types"
+import {verifyToken} from "@/utils/verifyToken"
 
 /**
  * @method DELETE
@@ -30,11 +31,10 @@ export async function DELETE(request: NextRequest, { params }: props) {
         }
 
         // const authToken = request.headers.get("authToken") as string
-        const cookieToken = request.cookies.get("cookieToken")
-        const token = cookieToken?.value as string
 
-        const authTokenFromTheUser = jsonwebtoken.verify(token, process.env.JWT_KEY as string) as typeJwt
-        if (authTokenFromTheUser.id === userAccount.id) {
+
+        const authTokenFromTheUser = verifyToken(request)
+        if ( authTokenFromTheUser !== null && authTokenFromTheUser.id === userAccount.id) {
             await prisma.user.delete({ where: { id: parseInt(params.id) } })
             return NextResponse.json({ message: "Your Profile Account Has Been Deleted" }, { status: 200 })
         }

--- a/src/utils/verifyToken.ts
+++ b/src/utils/verifyToken.ts
@@ -1,0 +1,24 @@
+import jsonwebtoken from "jsonwebtoken";
+import { NextRequest } from "next/server";
+import { typeJwt } from "@/utils/types";
+
+export function verifyToken(request: NextRequest): typeJwt | null {
+    try {
+        // Retrieve the token from cookies
+        const cookieToken = request.cookies.get("cookieToken");
+        const token = cookieToken?.value as string;
+
+        if (!token) return null;
+
+        // Get the secret key for verifying the JWT
+        const secretKey = process.env.JWT_KEY as string;
+
+        // Verify the token and cast it to `unknown` first to safely cast it to `typeJwt`
+        const payload = jsonwebtoken.verify(token, secretKey) as unknown as typeJwt;
+
+        return payload;  // Return the decoded payload
+    } catch (error) {
+        console.error("Error Verifying The Token. Try again later:", error);  // Log the actual error
+        return null;  // Return null on error or token verification failure
+    }
+}


### PR DESCRIPTION
- Added `verifyToken` function to `utils/verifyToken` for validating and decoding JWT tokens from cookies.
- The function retrieves the JWT from the `cookieToken`, verifies it using `jsonwebtoken.verify`, and returns the decoded payload (`typeJwt`) or `null` if the token is invalid.
- Refactored DELETE route for profile deletion to use the `verifyToken` function for checking authorization.
- Improved the DELETE handler by replacing direct token handling with the new utility, enhancing code modularity and reusability.
- Added error handling in `verifyToken` to log verification errors and return `null` on failure.