### PR TITLE
Implement comment editing with user authentication and validation

### DIFF
--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "@/utils/db";
+import { verifyToken } from "@/utils/verifyToken"
+import { string } from "zod";
+import { editComment } from "@/utils/postType";
+
+
+interface props {
+    params: { id: string }
+}
+
+
+export async function PUT(request: NextRequest, { params }: props) {
+    try {
+        const comment = await prisma.comment.findUnique({ where: { id: parseInt(params.id) } })
+        if (!comment) {
+            return NextResponse.json({ message: "Comment Not Foun" }, { status: 404 })
+        }
+
+        const user = verifyToken(request)
+
+        if (user === null || user.id !== comment.id) {
+            return NextResponse.json({ message: "You Are Not Allowed To Edit The Comment" }, { status: 403 })
+        }
+
+        const body = await request.json() as editComment
+
+        const updatdeComment = await prisma.comment.update({
+            where: { id: parseInt(params.id) }, data: {
+                text: body.text
+            }
+        })
+
+        return NextResponse.json(updatdeComment, { status: 200 })
+    } catch (error) {
+        console.error("Error Editing Comment.Try again later:", error); // Log the actual error
+        return NextResponse.json({ message: "Internal server error" }, { status: 500 });
+    }
+}
+

--- a/src/utils/postType.ts
+++ b/src/utils/postType.ts
@@ -29,3 +29,7 @@ export interface addComment{
     text: string,
     articleId: number
 }
+
+export interface editComment{
+    text: string,
+}


### PR DESCRIPTION
- Added a PUT request handler to allow users to edit their comments.
- Implemented JWT authentication using `verifyToken` to ensure that only the comment owner can edit the comment.
- Added validation to check if the comment exists before attempting to update.
- Restricted access to editing, returning a 403 status if the user is not the owner of the comment.
- Updated the comment text using `prisma.comment.update()` for the authorized user.
- Included error handling for cases of missing comments, unauthorized access, and internal server errors.
- Returned appropriate status codes: 404 for not found, 403 for unauthorized, and 200 for successful update.