### PR TITLE
Implement pagination for GET /api/articles endpoint

### DIFF
--- a/src/app/api/articles/route.ts
+++ b/src/app/api/articles/route.ts
@@ -5,6 +5,7 @@ import { typeArticles } from "@/utils/types";
 import { newArticleSchema } from "@/utils/validation"
 import { createArticle } from "@/utils/postType"
 import prisma from "@/utils/db"
+import {numberOfArticles} from "@/utils/constants"
 import { title } from "process";
 import { error } from "console";
 
@@ -13,10 +14,10 @@ import { error } from "console";
 
 /**
  * @method GET 
- * @route http://localhost:3000/api/articles
+ * @route http://localhost:3000/api/articles?pageNumber=1
  * @access public
  * @description 
- *  - Created GET handler for fetching articles data using Next.js API routes.
+ *  - Created GET handler for fetching articles data using Next.js API routes based on the pagination.
     - Utilized `NextRequest` and `NextResponse` from "next/server" to return the data.
     - Added a status code of 200 for successful responses.
     - Imported articles data from the utils/data file for the response.
@@ -24,7 +25,12 @@ import { error } from "console";
 
 export async function GET(request: NextRequest) {
     try {
-        const getArticle = await prisma.article.findMany();
+        const pageNumber = request.nextUrl.searchParams.get("pageNumber") || "1"
+        
+        const getArticle = await prisma.article.findMany({
+            skip : numberOfArticles * (parseInt(pageNumber) - 1),
+            take : numberOfArticles
+        });
         return NextResponse.json(getArticle, { status: 200 })
     } catch (error) {
         console.error("Error fetching articles:", error); // Log the actual error

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const numberOfArticles = 6


### PR DESCRIPTION
- Added a GET handler to fetch articles based on pagination using `pageNumber` query parameter.
- Integrated `NextRequest` and `NextResponse` to handle API requests and responses.
- Implemented pagination logic with `skip` and `take` to control the number of articles retrieved per page.
- Handled success responses with a 200 status code and proper error handling for server-side issues.
- Articles are fetched from the Prisma ORM to retrieve data from the database.





