### PR TITLE
Enhanced article search functionality with case-insensitive matching

### DIFF
--- a/src/app/api/articles/search/route.ts
+++ b/src/app/api/articles/search/route.ts
@@ -18,7 +18,10 @@ export async function GET(request:NextRequest){
         const searchText = request.nextUrl.searchParams.get("searchText")
         let articles;
         if(searchText){
-            articles = await prisma.article.findMany({where : {title : searchText}})
+            articles = await prisma.article.findMany({where : {title : {
+                startsWith: searchText,
+                mode : "insensitive"
+            }}})
         } else{
             articles = await prisma.article.findMany({take : 6})
         }


### PR DESCRIPTION
- Updated the search query to use `startsWith` for filtering article titles, allowing partial matches based on the beginning of the title.
- Added `mode: "insensitive"` to make the search case-insensitive, improving the user experience by making searches more flexible and accommodating.
- This update enables users to find articles more easily, even if they don't match the exact case or full title.