### PR TITLE
Added logic to delete associated comments when deleting an article.

### DIFF
--- a/prisma/migrations/20241005074511_add_on_delete_action_on_comment_table/migration.sql
+++ b/prisma/migrations/20241005074511_add_on_delete_action_on_comment_table/migration.sql
@@ -1,0 +1,11 @@
+-- DropForeignKey
+ALTER TABLE "comment" DROP CONSTRAINT "comment_articleId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "comment" DROP CONSTRAINT "comment_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "comment" ADD CONSTRAINT "comment_articleId_fkey" FOREIGN KEY ("articleId") REFERENCES "Article"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "comment" ADD CONSTRAINT "comment_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,6 @@ model comment {
   updatedAt DateTime @updatedAt
   articleId Int
   userId    Int
-  article   Article  @relation(fields: [articleId], references: [id])
-  user      User     @relation(fields: [userId], references: [id])
+  article   Article  @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/src/app/api/articles/[id]/route.ts
+++ b/src/app/api/articles/[id]/route.ts
@@ -100,11 +100,18 @@ interface articleId {
 
 export async function DELETE(request: NextRequest, { params }: articleId) {
     try {
-        const singleArticle = await prisma.article.findUnique({ where: { id: parseInt(params.id) } });
+        const singleArticle = await prisma.article.findUnique({ where: { id: parseInt(params.id) }, include:{
+            comments : true
+        } });
         if (!singleArticle) {
             return NextResponse.json({ message: "Article Not Found" }, { status: 404 })
         }
+
         await prisma.article.delete({ where: { id: parseInt(params.id) } })
+
+        const articleCommentId = singleArticle?.comments.map(comment => comment.id)
+        await prisma.comment.deleteMany({where: {id :{in : articleCommentId}}})
+
         return NextResponse.json({ message: "Article deleted" }, { status: 200 });
     } catch (error) {
         console.error("Error deleting article:", error); // Log the actual error


### PR DESCRIPTION
- Updated the DELETE method to include article's related comments in the deletion process.
- Implemented `include: { comments: true }` in `findUnique()` to retrieve all associated comments of the article.
- Added logic to map the comment IDs from the article and delete all associated comments using `prisma.comment.deleteMany()`.
- Ensures that when an article is deleted, its comments are also removed, maintaining database integrity.