### PR TITLE
Add single article fetching and typing with `typeSingleArticle

### DIFF
--- a/src/apiCalles/getArticlesApi.ts
+++ b/src/apiCalles/getArticlesApi.ts
@@ -45,3 +45,12 @@ export async function getSearchedArticle(searchText: string): Promise<Article[]>
     }
     return SearchedArticle.json();
 }
+
+
+export async function getSingleArticle(articleId: string){
+    const response = await fetch(`http://localhost:3000/api/articles/${articleId}`)
+    if(!response.ok){
+        throw new Error("Error fetching single article")
+    }
+    return response.json();
+}

--- a/src/app/article/[id]/page.tsx
+++ b/src/app/article/[id]/page.tsx
@@ -1,7 +1,9 @@
+import { getSingleArticle } from "@/apiCalles/getArticlesApi"
 import AddArticleForm from "@/app/admin/AddArticleForm"
 import AddCommentForm from "@/app/components/Comment/AddCommentForm"
 import CommentItem from "@/app/components/Comment/CommentItem"
-import {typeArticles} from "@/utils/types"
+import { typeSingleArticle } from "@/utils/types"
+import { Article } from "@prisma/client"
 import { promises } from "dns"
 import { resolve } from "path"
 
@@ -10,17 +12,14 @@ interface singleArticle{
 }
 
 const singleArticlePage = async ({params}:singleArticle) => {
-    const response = await fetch(`https://jsonplaceholder.typicode.com/posts/${params.id}`)
-    if(!response.ok){
-        throw new Error("Error fetching single article")
-    }
-    const singleArticle: typeArticles = await response.json();
+
+    const singleArticle: typeSingleArticle = await getSingleArticle(params.id);
     return (
         <section className="fix-height container m-auto w-full px-5 pt-8 md:w-3/4">
             <div className="bg-white p-7 rounded-lg mb-7">
                 <h1 className=" text-3xl font-bold text-gray-700 mb-2">{singleArticle.title}</h1>
-                <div className="text-gray-400">1/1/2024</div>
-                <p className="text-gray-800 text-xl mt-5">{singleArticle.body}</p>
+                <div className="text-gray-400">{new Date(singleArticle.createdAt).toDateString()}</div>
+                <p className="text-gray-800 text-xl mt-5">{singleArticle.description}</p>
             </div>
             <AddCommentForm/>
             <h4 className="text-xl text-gray-800 ps-1 font-semibold mb-2 mt-7">


### PR DESCRIPTION
- Implemented `getSingleArticle` function to fetch details of a specific article by `articleId` from the API, with error handling to manage failed requests.
- Defined `typeSingleArticle` to represent a single article's structure, including associated comments and user information.
- Ensured `typeSingleArticle` extends the base `Article` type, enriching it with `commentWithUser` which includes comments along with user data for each comment.
- Enhanced type safety and data consistency for single article rendering and comment display.