### PR TITLE
Prevent logged-in users from accessing login and register pages

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import LogInForm from './LogInForm'
-import { redirect } from 'next/navigation'
-import { cookies } from 'next/headers'
+// import { redirect } from 'next/navigation'
+// import { cookies } from 'next/headers'
 
 const LogIn = () => {
-    const token  = cookies().get("cookieToken")?.value
-    if(token){
-        redirect("/")
-    }
+    // This code has been added to the middleware
+    // const token  = cookies().get("cookieToken")?.value
+    // if(token){
+    //     redirect("/")
+    // }
     return (
         <section className='fix-height container px-7 flex items-center justify-center pt-16'>
             <div className='m-auto bg-white rounded-lg p-5 w-2/3 md:h-2/3 '>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import RegisterForm from './RegisterForm'
-import { redirect } from 'next/navigation'
-import { cookies } from 'next/headers'
+// import { redirect } from 'next/navigation'
+// import { cookies } from 'next/headers'
 
 
 
 const Register = () => {
-    const token  = cookies().get("cookieToken")?.value
-    if(token){
-        redirect("/")
-    }
+    // This code has been added to the middleware
+    // const token  = cookies().get("cookieToken")?.value
+    // if(token){
+    //     redirect("/")
+    // }
     return (
         <section className='fix-height container px-7 flex items-center justify-center pt-16'>
         <div className='m-auto bg-white rounded-lg p-5 w-2/3 md:h-2/3 '>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,15 +1,27 @@
 import { NextRequest, NextResponse } from "next/server";
 
 export function middleware(request: NextRequest) {
-    // const authToken = request.headers.get("authT")
-    const cookieToken = request.cookies.get("cookieToken")
-    const token = cookieToken?.value as string
+    const cookieToken = request.cookies.get("cookieToken");
+    const token = cookieToken?.value as string;
+
     if (!token) {
-        return NextResponse.json({ message: "No Token Provided" }, { status: 401 })
+        if (request.nextUrl.pathname.startsWith("/api/user/profile")) {
+            return NextResponse.json({ message: "No Token Provided" }, { status: 401 });
+        }
+    } else {
+        if (
+            request.nextUrl.pathname === "/login" ||
+            request.nextUrl.pathname === "/register"
+        ) {
+            return NextResponse.redirect(new URL("/", request.url));
+        }
     }
 }
 
 export const config = {
-    matcher:["/api/user/profile:path*"]
-}
+    matcher: ["/api/user/profile", "/login", "/register"],
+};
+
+
+
 


### PR DESCRIPTION
- Added middleware to check for a valid authentication token (`cookieToken`).
- Redirect logged-in users from `/login` and `/register` to the homepage (`/`).
- Ensured unauthenticated users can access `/login` and `/register`.
- Applied middleware to specific routes using `matcher`.
